### PR TITLE
Moving CMDs from Dockerfile to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,3 @@ COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 
 COPY . /code/
-
-CMD ["python", "manage.py makemigrations --noinput"]
-CMD ["python", "manage.py migrate --run-syncdb"]
-
-CMD ["python", "populate_moviegeek.py"]
-CMD ["python", "populate_ratings.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
   web:
     restart: always
     build: .
-    command: python manage.py runserver 0.0.0.0:8010
+    command: >
+      bash -c "python manage.py makemigrations --noinput &&
+               python manage.py migrate --run-syncdb &&
+               python manage.py runserver 0.0.0.0:8010"
     volumes:
       - .:/code
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     command: >
       bash -c "python manage.py makemigrations --noinput &&
                python manage.py migrate --run-syncdb &&
+               python populate_moviegeek.py &&
+               python populate_ratings.py &&
                python manage.py runserver 0.0.0.0:8010"
     volumes:
       - .:/code


### PR DESCRIPTION
The command in docker-compose would override the CMDs in Dockerfile.
Move these CMDs to docker-compose to take effect.

This PR fixes #2 