### PR TITLE
Fix when titles are longer than 128 characters

### DIFF
--- a/moviegeeks/models.py
+++ b/moviegeeks/models.py
@@ -10,7 +10,7 @@ class Genre(models.Model):
 
 class Movie(models.Model):
     movie_id = models.CharField(max_length=16, unique=True, primary_key=True)
-    title = models.CharField(max_length=128)
+    title = models.CharField(max_length=512)
     year = models.IntegerField(null=True)
     genres = models.ManyToManyField(Genre, related_name='movies', db_table='movie_genre')
 


### PR DESCRIPTION
For longer than 128 characters [Title: Lethal Kittens or how we came to Love our Shovels during a Limited Anti-Terrorist Operation with Temporary Elements of a State of War (2020) ] 140 characters python3 populate_moviegeek.py setup was failing. 
This commit fixes #4