### PR TITLE
moving around populate command to docker-compose, and adding volume to persist data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,3 @@ COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 
 COPY . /code/
-
-CMD ["python", "manage.py makemigrations --noinput"]
-CMD ["python", "manage.py migrate --run-syncdb"]
-
-CMD ["python", "populate_moviegeek.py"]
-CMD ["python", "populate_ratings.py"]

--- a/README.md
+++ b/README.md
@@ -56,16 +56,20 @@ I recommend the first option, as the docker container way is faster and requires
 
 ### Run site in a Docker container 
 
-As a new addition to this site, this repo will also have a docker container, which should make it 
-easier to start. 
+As a new addition to this site, this repo will also have a docker container, which should make it easier to start. 
 
-Fire up the website simply by first building the docker container
+0. Populate movie and rating data to the database first.
+```shell script
+docker-compose run seed
+```
+
+1. Fire up the website simply by first building the docker container
 
 ```shell script
 docker-compose build web
 ```
 
-And then start it executing the following:
+2. And then start it executing the following:
 
 ```shell script
 docker-compose up web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - POSTGRES_PASSWORD=pw1234
       - POSTGRES_DB=moviegeeks
     volumes:
-      - recs-db
+      - recs-db:/var/lib/postgresql/data 
 
   web:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=pw1234
       - POSTGRES_DB=moviegeeks
+    volumes:
+      - recs-db
+
   web:
     restart: always
     build: .
@@ -36,3 +39,18 @@ services:
     command: jupyter notebook
     ports:
       - "8888:8888"
+
+  seed:
+    build: .
+    command: >
+      bash -c "python manage.py makemigrations --noinput &&
+               python manage.py migrate --run-syncdb &&
+               python populate_moviegeek.py &&
+               python populate_ratings.py"
+    volumes:
+      - .:/code
+    depends_on:
+      - db
+
+volumes:
+  recs-db:


### PR DESCRIPTION
This change fixes #2 

1. moving migration and populating related commands to a seed service in docker-compose
2. adding volume to persist populated data, so it only populates data with `docker-compose run seed` and persist the database in a volume. The next time user runs `docker-compose up web` and `docker-compose down web`, the data will always be persist. (`docker-compose down web -v` or `docker-compose stop web` would delete the volume by the design of docker-compose)